### PR TITLE
change type from Pubkey to String for QuoteConfig dexes & excludeDexes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,8 +221,8 @@ impl fmt::Display for SwapMode {
 pub struct QuoteConfig {
     pub slippage_bps: Option<u64>,
     pub swap_mode: Option<SwapMode>,
-    pub dexes: Option<Vec<Pubkey>>,
-    pub exclude_dexes: Option<Vec<Pubkey>>,
+    pub dexes: Option<Vec<String>>,
+    pub exclude_dexes: Option<Vec<String>>,
     pub only_direct_routes: bool,
     pub as_legacy_transaction: Option<bool>,
     pub platform_fee_bps: Option<u64>,


### PR DESCRIPTION
The `QuoteConfig` struct used to get swap quote supports optional parameters like dexes & excludeDexes has type of `Vec<Pubkey>`, where the API supports names of dexes which is `Vec<String>`

### References:

- https://station.jup.ag/api-v6/get-quote
- https://quote-api.jup.ag/v6/program-id-to-label

### Examples:

#### Successful Quotes:

```
curl -L 'https://quote-api.jup.ag/v6/quote?inputMint=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v&outputMint=So11111111111111111111111111111111111111112&amount=1000000000&dexes=Orca%20V2' \
-H 'Accept: application/json'
```

```
curl -L 'https://quote-api.jup.ag/v6/quote?inputMint=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v&outputMint=So11111111111111111111111111111111111111112&amount=1000000000&excludeDexes=Orca%20V2' \
-H 'Accept: application/json'
```

#### Failed quotes with program id

```
curl -L 'https://quote-api.jup.ag/v6/quote?inputMint=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v&outputMint=So11111111111111111111111111111111111111112&amount=1000000000&excludeDexes=CTMAxxk34HjKWxQ3QLZK1HpaLXmBveao3ESePXbiyfzh' \
-H 'Accept: application/json'
```

