### PR TITLE
Adjust quote and swap requests to the new API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,9 @@ mod field_pubkey;
 /// A `Result` alias where the `Err` case is `jup_ag::Error`.
 pub type Result<T> = std::result::Result<T, Error>;
 
-// Reference: https://quote-api.jup.ag/v4/docs/static/index.html
+// Reference: https://dev.jup.ag/docs/api/swap-api/quote
 fn quote_api_url() -> String {
-    env::var("QUOTE_API_URL").unwrap_or_else(|_| "https://quote-api.jup.ag/v6".to_string())
+    env::var("QUOTE_API_URL").unwrap_or_else(|_| "https://lite-api.jup.ag/swap/v1".to_string())
 }
 
 // Reference: https://quote-api.jup.ag/docs/static/index.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,10 +79,10 @@ pub struct Quote {
     pub other_amount_threshold: u64,
     pub swap_mode: String,
     pub slippage_bps: u64,
-    pub platform_fee: Option<PlatformFee>,
     #[serde(with = "field_as_string")]
     pub price_impact_pct: f64,
     pub route_plan: Vec<RoutePlan>,
+    pub platform_fee: Option<PlatformFee>,
     pub context_slot: Option<u64>,
     pub time_taken: Option<f64>,
 }
@@ -107,19 +107,15 @@ pub struct RoutePlan {
 pub struct SwapInfo {
     #[serde(with = "field_as_string")]
     pub amm_key: Pubkey,
-    pub label: Option<String>,
-    #[serde(with = "field_as_string")]
-    pub input_mint: Pubkey,
-    #[serde(with = "field_as_string")]
-    pub output_mint: Pubkey,
     #[serde(with = "field_as_string")]
     pub in_amount: u64,
     #[serde(with = "field_as_string")]
+    pub input_mint: Pubkey,
+    pub label: Option<String>,
+    #[serde(with = "field_as_string")]
     pub out_amount: u64,
     #[serde(with = "field_as_string")]
-    pub fee_amount: u64,
-    #[serde(with = "field_as_string")]
-    pub fee_mint: Pubkey,
+    pub output_mint: Pubkey,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
This updates the quote and swap requests to use the new required x-api-key header.
The api key is required for the new api endpoint. The old endpoint won't be available after January 31.

https://dev.jup.ag/portal/migrate-from-lite-api

Also I'm not sure what to do with the example programs, which probably need a valid API key to run successfully.